### PR TITLE
Avoid infinite loops in case of dep loops

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -120,6 +120,9 @@ fn report_dependencies(dependency_tree: &Tree, packages: &HashSet<String>) -> Ve
         while let Some(u) = bfs.next(&graph) {
             for v in graph.neighbors(u) {
                 let package = &graph[v];
+                if predecessor.contains(&v) {
+                    continue;
+                }
                 predecessor[v.index()] = u;
 
                 let dependency_path = dependency_path(&predecessor, v);


### PR DESCRIPTION
The program would infinite loop on a private monorepo due to a loop in the dependency tree (X depends on Y, Y depends on X), like so:

<img width="232" alt="image" src="https://github.com/dcoles/gitlab-cargo-audit/assets/1069318/3c52e056-c59a-4919-87c6-c909a93f90af">

This can happen with dev-dependency. obflog depends on obflog-derive, while obflog-derive has a dev dependency on obflog.

This can cause dependency path algorithm to enter an infinite loop.