### PR TITLE
Add optional `--output-path` parameter, forcing UTF-8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b3d0060af21e8d11a926981cc00c6c1541aa91dd64b9f881985c3da1094425f"
 
 [[package]]
+name = "argh"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7af5ba06967ff7214ce4c7419c7d185be7ecd6cc4965a8f6e1d8ce0398aad219"
+dependencies = [
+ "argh_derive",
+ "argh_shared",
+]
+
+[[package]]
+name = "argh_derive"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56df0aeedf6b7a2fc67d06db35b09684c3e8da0c95f8f27685cb17e08413d87a"
+dependencies = [
+ "argh_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "argh_shared"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5693f39141bda5760ecc4111ab08da40565d1771038c4a0250f03457ec707531"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,6 +556,7 @@ name = "gitlab-cargo-audit"
 version = "0.4.0"
 dependencies = [
  "anyhow",
+ "argh",
  "env_logger",
  "petgraph",
  "rustsec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1"
+argh = { version = "0.1.12" }
 env_logger = "0.11.3"
 petgraph = "0.6.4"
 rustsec = { version = "0.28.4", features = ["dependency-tree"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ const ISO8601_CFG: iso8601::EncodedConfig = iso8601::Config::DEFAULT
 /// produces a gitlab consumable cargo-audit report
 #[derive(FromArgs)]
 struct App {
-    /// an optional output path
+    /// an optional output path.
     ///
     /// contents are written as utf-8
     #[argh(option)]
@@ -108,7 +108,7 @@ fn main() -> anyhow::Result<()> {
 
     let output: Box<dyn std::io::Write> = match app.output_path {
         Some(path) => {
-            let output = std::fs::File::create(path).unwrap();
+            let output = std::fs::File::create(path)?;
             Box::new(output)
         }
         None => Box::new(io::stdout().lock()),


### PR DESCRIPTION
Adds a optional `--output-path` parameter, which always encodes in UTF-8.

I brought in argh to do this work, I believe it should be minimal enough.

In #8 I noted that the output needs set to UTF-8. This isn't correct. Turns out that for example, PowerShell (note PowerShell Core) defaults `>` aka `Out-File` to UTF-16.

```powershell
> .\target\debug\gitlab-cargo-audit.exe --help
Usage: gitlab-cargo-audit.exe [--output-path <output-path>]

produces a gitlab consumable cargo-audit report

Options:
  --output-path     an optional output path. contents are written as utf-8
  --help            display usage information
```